### PR TITLE
Add a Nix flake

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+((nil
+  (fill-column . 100)
+  (indent-tabs-mode . nil)
+  (sentence-end-double-space . nil)))

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Don’t render generated files by default in GitHub diffs
+flake.lock linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Nix build
 /outputs
-/result
+/result*
 /source
 
 # Compiled

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Direnv
+/.direnv
+
+# Nix build
+/outputs
+/result
+/source
+
+# Compiled
+*.elc
+
+# Packaging
+/.eldev

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,1 @@
+;; -*- mode: emacs-lisp; lexical-binding: t; -*-

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,135 @@
+{
+  "nodes": {
+    "bash-strict-mode": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "shellcheck-nix-attributes": "shellcheck-nix-attributes"
+      },
+      "locked": {
+        "lastModified": 1671717013,
+        "narHash": "sha256-zN2FywQLDgUgFft3kt3j9zH/F271zdxZoUBfOIGI07k=",
+        "owner": "sellout",
+        "repo": "bash-strict-mode",
+        "rev": "b35a80270ef436266179752313c950ebfa614abe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sellout",
+        "repo": "bash-strict-mode",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "homeManager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1672244468,
+        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-22.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1673010400,
+        "narHash": "sha256-nz8lNxTKEuV9cbEj/Use513PMA3+QXyt2ABvy+upoFo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4ddb962be28423343a5c691bf8ebc774e18971b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bash-strict-mode": "bash-strict-mode",
+        "flake-utils": "flake-utils_2",
+        "homeManager": "homeManager",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "shellcheck-nix-attributes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1586929030,
+        "narHash": "sha256-a0WyWaz+nMYFWI43Ip9EUnPuBW0O4EIiTzYZKGqNjss=",
+        "owner": "Fuuzetsu",
+        "repo": "shellcheck-nix-attributes",
+        "rev": "51b49d5fe65ece69eb5e2003396bf096083ec281",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Fuuzetsu",
+        "repo": "shellcheck-nix-attributes",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,18 @@
     "bash-strict-mode": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "home-manager": "home-manager",
         "nixpkgs": [
           "nixpkgs"
         ],
         "shellcheck-nix-attributes": "shellcheck-nix-attributes"
       },
       "locked": {
-        "lastModified": 1671717013,
-        "narHash": "sha256-zN2FywQLDgUgFft3kt3j9zH/F271zdxZoUBfOIGI07k=",
+        "lastModified": 1673387613,
+        "narHash": "sha256-q5lyL21JBSpuDNNRQt65IzWD1Gra7LNf7nw3KkpSn78=",
         "owner": "sellout",
         "repo": "bash-strict-mode",
-        "rev": "b35a80270ef436266179752313c950ebfa614abe",
+        "rev": "4802d968b31bb5c748d3032f299f91a8d6d1280e",
         "type": "github"
       },
       "original": {
@@ -52,9 +53,10 @@
         "type": "github"
       }
     },
-    "homeManager": {
+    "home-manager": {
       "inputs": {
         "nixpkgs": [
+          "bash-strict-mode",
           "nixpkgs"
         ],
         "utils": "utils"
@@ -74,13 +76,35 @@
         "type": "github"
       }
     },
+    "homeManager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1672244468,
+        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-22.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673010400,
-        "narHash": "sha256-nz8lNxTKEuV9cbEj/Use513PMA3+QXyt2ABvy+upoFo=",
+        "lastModified": 1673391659,
+        "narHash": "sha256-iz4359AMaEhCIZPaLfOX2jLwMWxbLnKwiAp5l+s06nE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4ddb962be28423343a5c691bf8ebc774e18971b",
+        "rev": "9e00bb203130943ea98eb215950bbb42ceeef380",
         "type": "github"
       },
       "original": {
@@ -115,6 +139,21 @@
       }
     },
     "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",

--- a/flake.lock
+++ b/flake.lock
@@ -23,22 +23,27 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "lastModified": 1673362319,
+        "narHash": "sha256-Pjp45Vnj7S/b3BRpZEVfdu8sqqA6nvVjvYu59okhOyI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "82c16f1682cf50c01cb0280b38a1eed202b3fe9f",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -76,7 +81,7 @@
         "type": "github"
       }
     },
-    "homeManager": {
+    "home-manager_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -117,8 +122,8 @@
     "root": {
       "inputs": {
         "bash-strict-mode": "bash-strict-mode",
-        "flake-utils": "flake-utils_2",
-        "homeManager": "homeManager",
+        "flake-parts": "flake-parts",
+        "home-manager": "home-manager_2",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -117,12 +117,12 @@
             ++ builtins.attrValues inputs.self.packages.${system};
 
           nativeBuildInputs = [
+            # Nix language server,
+            # https://github.com/oxalica/nil#readme
+            pkgs.nil
             # Bash language server,
             # https://github.com/bash-lsp/bash-language-server#readme
             pkgs.nodePackages.bash-language-server
-            # Nix language server,
-            # https://github.com/nix-community/rnix-lsp#readme
-            pkgs.rnix-lsp
           ];
         });
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,199 @@
+{
+  description = "Decrypt and encrypt agenix secrets inside Emacs";
+
+  outputs = inputs:
+    {
+      overlays = {
+        default = final: prev: {
+          emacsPackagesFor = emacs:
+            (prev.emacsPackagesFor emacs).overrideScope'
+            (inputs.self.overlays.emacs final prev);
+        };
+
+        emacs = final: prev: efinal: eprev: {
+          agenix = inputs.self.packages.${final.system}.agenix-el;
+        };
+      };
+
+      homeConfigurations.example = inputs.homeManager.lib.homeManagerConfiguration {
+        pkgs = import inputs.nixpkgs {
+          system = inputs.flake-utils.lib.system.aarch64-darwin;
+          ## Users will refer to `inputs.agenix-el.overlays.default` instead.
+          overlays = [inputs.self.overlays.default];
+        };
+
+        modules = [
+          ./nix/home-manager-example.nix
+          {
+            # These attributes are simply required by home-manager.
+            home = {
+              homeDirectory = /tmp/agenix-el-example;
+              stateVersion = "22.11";
+              username = "agenix-el-example-user";
+            };
+          }
+        ];
+      };
+    }
+    // inputs.flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [(import ./nix/dependencies.nix)];
+      };
+
+      src = pkgs.lib.cleanSource ./.;
+
+      emacsPackageDir = "share/emacs/site-lisp/elpa";
+
+      emacsPath = package: "${package}/${emacsPackageDir}/${package.ename}-${package.version}";
+
+      ## We need to tell Eldev where to find its Emacs package.
+      ELDEV_LOCAL = emacsPath pkgs.emacsPackages.eldev;
+    in {
+      packages = {
+        default = inputs.self.packages.${system}.agenix-el;
+
+        agenix-el =
+          inputs.bash-strict-mode.lib.checkedDrv pkgs
+          (pkgs.emacsPackages.trivialBuild (let
+            pname = "agenix";
+            version = "0.2";
+          in {
+            inherit ELDEV_LOCAL pname src version;
+
+            nativeBuildInputs = [
+              pkgs.emacs
+              # Emacs-lisp build tool, https://doublep.github.io/eldev/
+              pkgs.emacsPackages.eldev
+            ];
+
+            doCheck = true;
+
+            checkPhase = ''
+              runHook preCheck
+              eldev test
+              runHook postCheck
+            '';
+
+            doInstallCheck = true;
+
+            instalCheckPhase = ''
+              runHook preInstallCheck
+              eldev --packaged test
+              runHook postInstallCheck
+            '';
+          }));
+      };
+
+      devShells.default =
+        ## TODO: Use `inputs.bash-strict-mode.lib.checkedDrv` here after
+        ##       NixOS/nixpkgs#204606 makes it into a release.
+        inputs.bash-strict-mode.lib.drv pkgs
+        (pkgs.mkShell {
+          inputsFrom =
+            builtins.attrValues inputs.self.checks.${system}
+            ++ builtins.attrValues inputs.self.packages.${system};
+
+          nativeBuildInputs = [
+            # Bash language server,
+            # https://github.com/bash-lsp/bash-language-server#readme
+            pkgs.nodePackages.bash-language-server
+            # Nix language server,
+            # https://github.com/nix-community/rnix-lsp#readme
+            pkgs.rnix-lsp
+          ];
+        });
+
+      checks = {
+        doctor =
+          inputs.bash-strict-mode.lib.checkedDrv pkgs
+          (pkgs.stdenv.mkDerivation {
+            inherit ELDEV_LOCAL src;
+
+            name = "eldev-doctor";
+
+            nativeBuildInputs = [
+              pkgs.emacs
+              # Emacs-lisp build tool, https://doublep.github.io/eldev/
+              pkgs.emacsPackages.eldev
+            ];
+
+            buildPhase = ''
+              runHook preBuild
+              eldev doctor
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p "$out"
+              runHook postInstall
+            '';
+          });
+
+        lint =
+          inputs.bash-strict-mode.lib.checkedDrv pkgs
+          (pkgs.stdenv.mkDerivation {
+            inherit ELDEV_LOCAL src;
+
+            name = "eldev-lint";
+
+            nativeBuildInputs = [
+              pkgs.emacs
+              pkgs.emacsPackages.eldev
+            ];
+
+            postPatch = ''
+              { echo
+                echo "(mapcar"
+                echo " 'eldev-use-local-dependency"
+                echo " '(\"${emacsPath pkgs.emacsPackages.dash}\""
+                echo "   \"${emacsPath pkgs.emacsPackages.elisp-lint}\""
+                echo "   \"${emacsPath pkgs.emacsPackages.package-lint}\""
+                echo "   \"${emacsPath pkgs.emacsPackages.relint}\""
+                echo "   \"${emacsPath pkgs.emacsPackages.xr}\"))"
+              } >> Eldev
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+              ## TODO: Currently needed to make a temp file in
+              ##      `eldev--create-internal-pseudoarchive-descriptor`.
+              export HOME="$PWD/fake-home"
+              mkdir -p "$HOME"
+              ## NB: Need `--external` here so that we don’t try to download any
+              ##     package archives (which would break the sandbox).
+              ## TODO: Re-enable relint, currently it errors, I think because it
+              ##       or Eldev is expecting a multi-file package.
+              eldev --external lint doc elisp # re
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p "$out"
+              runHook preInstall
+            '';
+          });
+      };
+
+      # Nix code formatter, https://github.com/kamadorueda/alejandra#readme
+      formatter = pkgs.alejandra;
+    });
+
+  inputs = {
+    bash-strict-mode = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = github:sellout/bash-strict-mode;
+    };
+
+    flake-utils.url = github:numtide/flake-utils;
+
+    homeManager = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = github:nix-community/home-manager/release-22.11;
+    };
+
+    nixpkgs.url = github:NixOS/nixpkgs/release-22.11;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,12 @@
 
       emacsPath = package: "${package}/${emacsPackageDir}/${package.ename}-${package.version}";
 
+      ## Read version in format: ;; Version: xx.yy
+      readVersion = fp:
+        builtins.elemAt
+        (builtins.match ".*(;; Version: ([[:digit:]]+\.[[:digit:]]+)).*" (builtins.readFile fp))
+        1;
+
       ## We need to tell Eldev where to find its Emacs package.
       ELDEV_LOCAL = emacsPath pkgs.emacsPackages.eldev;
     in {
@@ -75,7 +81,7 @@
             inherit ELDEV_LOCAL src;
 
             pname = "agenix";
-            version = "0.2";
+            version = readVersion ./agenix.el;
 
             nativeBuildInputs = [
               pkgs.emacs

--- a/flake.nix
+++ b/flake.nix
@@ -187,7 +187,7 @@
               ##     package archives (which would break the sandbox).
               ## TODO: Re-enable relint, currently it errors, I think because it
               ##       or Eldev is expecting a multi-file package.
-              eldev --external lint doc elisp # re
+              eldev --external lint elisp # re
               runHook postBuild
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,22 @@
 {
   description = "Decrypt and encrypt agenix secrets inside Emacs";
 
+  inputs = {
+    bash-strict-mode = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = github:sellout/bash-strict-mode;
+    };
+
+    flake-utils.url = github:numtide/flake-utils;
+
+    homeManager = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = github:nix-community/home-manager/release-22.11;
+    };
+
+    nixpkgs.url = github:NixOS/nixpkgs/release-22.11;
+  };
+
   outputs = inputs:
     {
       overlays = {
@@ -180,20 +196,4 @@
       # Nix code formatter, https://github.com/kamadorueda/alejandra#readme
       formatter = pkgs.alejandra;
     });
-
-  inputs = {
-    bash-strict-mode = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = github:sellout/bash-strict-mode;
-    };
-
-    flake-utils.url = github:numtide/flake-utils;
-
-    homeManager = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = github:nix-community/home-manager/release-22.11;
-    };
-
-    nixpkgs.url = github:NixOS/nixpkgs/release-22.11;
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,222 +4,230 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
 
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
     bash-strict-mode = {
       url = "github:sellout/bash-strict-mode";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    flake-utils.url = "github:numtide/flake-utils";
-
-    homeManager = {
+    home-manager = {
       url = "github:nix-community/home-manager/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
   outputs = inputs:
-    {
-      overlays = {
-        default = final: prev: {
-          emacsPackagesFor = emacs:
-            (prev.emacsPackagesFor emacs).overrideScope'
-            (inputs.self.overlays.emacs final prev);
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = inputs.nixpkgs.lib.systems.flakeExposed;
+      flake = {
+        overlays = {
+          default = final: prev: {
+            emacsPackagesFor = emacs:
+              (prev.emacsPackagesFor emacs).overrideScope'
+              (inputs.self.overlays.emacs final prev);
+          };
+
+          emacs = final: prev: efinal: eprev: {
+            agenix = inputs.self.packages.${final.system}.agenix-el;
+          };
         };
 
-        emacs = final: prev: efinal: eprev: {
-          agenix = inputs.self.packages.${final.system}.agenix-el;
-        };
-      };
+        homeConfigurations.example = inputs.home-manager.lib.homeManagerConfiguration {
+          pkgs = import inputs.nixpkgs {
+            system = inputs.flake-utils.lib.system.aarch64-darwin;
+            ## Users will refer to `inputs.agenix-el.overlays.default` instead.
+            overlays = [inputs.self.overlays.default];
+          };
 
-      homeConfigurations.example = inputs.homeManager.lib.homeManagerConfiguration {
-        pkgs = import inputs.nixpkgs {
-          system = inputs.flake-utils.lib.system.aarch64-darwin;
-          ## Users will refer to `inputs.agenix-el.overlays.default` instead.
-          overlays = [inputs.self.overlays.default];
-        };
-
-        modules = [
-          ./nix/home-manager-example.nix
-          {
-            # These attributes are simply required by home-manager.
-            home = {
-              homeDirectory = /tmp/agenix-el-example;
-              stateVersion = "22.11";
-              username = "agenix-el-example-user";
-            };
-          }
-        ];
-      };
-    }
-    // inputs.flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import inputs.nixpkgs {
-        inherit system;
-        overlays = [(import ./nix/dependencies.nix)];
-      };
-
-      src = pkgs.lib.cleanSource ./.;
-
-      emacsPackageDir = "share/emacs/site-lisp/elpa";
-
-      emacsPath = package: "${package}/${emacsPackageDir}/${package.ename}-${package.version}";
-
-      ## Read version in format: ;; Version: xx.yy
-      readVersion = fp:
-        builtins.elemAt
-        (builtins.match ".*(;; Version: ([[:digit:]]+\.[[:digit:]]+)).*" (builtins.readFile fp))
-        1;
-
-      ## We need to tell Eldev where to find its Emacs package.
-      ELDEV_LOCAL = emacsPath pkgs.emacsPackages.eldev;
-    in {
-      packages = {
-        default = inputs.self.packages.${system}.agenix-el;
-
-        agenix-el =
-          inputs.bash-strict-mode.lib.checkedDrv pkgs
-          (pkgs.emacsPackages.trivialBuild {
-            inherit ELDEV_LOCAL src;
-
-            pname = "agenix";
-            version = readVersion ./agenix.el;
-
-            nativeBuildInputs = [
-              pkgs.emacs
-              # Emacs-lisp build tool, https://doublep.github.io/eldev/
-              pkgs.emacsPackages.eldev
-            ];
-
-            doCheck = true;
-
-            checkPhase = ''
-              runHook preCheck
-              eldev test
-              runHook postCheck
-            '';
-
-            doInstallCheck = true;
-
-            instalCheckPhase = ''
-              runHook preInstallCheck
-              eldev --packaged test
-              runHook postInstallCheck
-            '';
-          });
-      };
-
-      devShells.default =
-        ## TODO: Use `inputs.bash-strict-mode.lib.checkedDrv` here after
-        ##       NixOS/nixpkgs#204606 makes it into a release.
-        inputs.bash-strict-mode.lib.drv pkgs
-        (pkgs.mkShell {
-          inputsFrom =
-            builtins.attrValues inputs.self.checks.${system}
-            ++ builtins.attrValues inputs.self.packages.${system};
-
-          nativeBuildInputs = [
-            # Nix language server,
-            # https://github.com/oxalica/nil#readme
-            pkgs.nil
-            # Bash language server,
-            # https://github.com/bash-lsp/bash-language-server#readme
-            pkgs.nodePackages.bash-language-server
+          modules = [
+            ./nix/home-manager-example.nix
+            {
+              # These attributes are simply required by home-manager.
+              home = {
+                homeDirectory = /tmp/agenix-el-example;
+                stateVersion = "22.11";
+                username = "agenix-el-example-user";
+              };
+            }
           ];
-        });
-
-      checks = {
-        doctor =
-          inputs.bash-strict-mode.lib.checkedDrv pkgs
-          (pkgs.stdenv.mkDerivation {
-            inherit ELDEV_LOCAL src;
-
-            name = "eldev-doctor";
-
-            nativeBuildInputs = [
-              pkgs.emacs
-              # Emacs-lisp build tool, https://doublep.github.io/eldev/
-              pkgs.emacsPackages.eldev
-            ];
-
-            buildPhase = ''
-              runHook preBuild
-              eldev doctor
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              runHook preInstall
-              mkdir -p "$out"
-              runHook postInstall
-            '';
-          });
-
-        lint =
-          inputs.bash-strict-mode.lib.checkedDrv pkgs
-          (pkgs.stdenv.mkDerivation {
-            inherit ELDEV_LOCAL src;
-
-            name = "eldev-lint";
-
-            nativeBuildInputs = [
-              pkgs.emacs
-              pkgs.emacsPackages.eldev
-            ];
-
-            postPatch = ''
-              { echo
-                echo "(mapcar"
-                echo " 'eldev-use-local-dependency"
-                echo " '(\"${emacsPath pkgs.emacsPackages.dash}\""
-                echo "   \"${emacsPath pkgs.emacsPackages.elisp-lint}\""
-                echo "   \"${emacsPath pkgs.emacsPackages.package-lint}\""
-                echo "   \"${emacsPath pkgs.emacsPackages.relint}\""
-                echo "   \"${emacsPath pkgs.emacsPackages.xr}\"))"
-              } >> Eldev
-            '';
-
-            buildPhase = ''
-              runHook preBuild
-              ## TODO: Currently needed to make a temp file in
-              ##      `eldev--create-internal-pseudoarchive-descriptor`.
-              export HOME="$PWD/fake-home"
-              mkdir -p "$HOME"
-              ## NB: Need `--external` here so that we don’t try to download any
-              ##     package archives (which would break the sandbox).
-              ## TODO: Re-enable relint, currently it errors, I think because it
-              ##       or Eldev is expecting a multi-file package.
-              eldev --external lint elisp # re
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              runHook preInstall
-              mkdir -p "$out"
-              runHook preInstall
-            '';
-          });
-
-        nix-fmt = pkgs.stdenv.mkDerivation {
-          inherit src;
-
-          name = "nix fmt";
-
-          nativeBuildInputs = [inputs.self.formatter.${system}];
-
-          buildPhase = ''
-            runHook preBuild
-            alejandra --check .
-            runHook postBuild
-          '';
-
-          installPhase = ''
-            runHook preInstall
-            mkdir -p "$out"
-            runHook preInstall
-          '';
         };
       };
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: let
+        src = pkgs.lib.cleanSource ./.;
+        emacsPackageDir = "share/emacs/site-lisp/elpa";
+        emacsPath = package: "${package}/${emacsPackageDir}/${package.ename}-${package.version}";
 
-      # Nix code formatter, https://github.com/kamadorueda/alejandra#readme
-      formatter = pkgs.alejandra;
-    });
+        # Read version in format: ;; Version: xx.yy
+        readVersion = fp:
+          builtins.elemAt
+          (builtins.match ".*(;; Version: ([[:digit:]]+\.[[:digit:]]+)).*" (builtins.readFile fp))
+          1;
+
+        # We need to tell Eldev where to find its Emacs package.
+        ELDEV_LOCAL = emacsPath pkgs.emacsPackages.eldev;
+      in {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [(import ./nix/dependencies.nix)];
+        };
+        packages = {
+          default = self'.packages.agenix-el;
+
+          agenix-el =
+            inputs.bash-strict-mode.lib.checkedDrv pkgs
+            (pkgs.emacsPackages.trivialBuild {
+              inherit ELDEV_LOCAL src;
+
+              pname = "agenix";
+              version = readVersion ./agenix.el;
+
+              nativeBuildInputs = [
+                pkgs.emacs
+                # Emacs-lisp build tool, https://doublep.github.io/eldev/
+                pkgs.emacsPackages.eldev
+              ];
+
+              doCheck = true;
+              checkPhase = ''
+                runHook preCheck
+                eldev test
+                runHook postCheck
+              '';
+
+              doInstallCheck = true;
+              instalCheckPhase = ''
+                runHook preInstallCheck
+                eldev --packaged test
+                runHook postInstallCheck
+              '';
+            });
+        };
+
+        devShells.default =
+          ## TODO: Use `inputs.bash-strict-mode.lib.checkedDrv` here after
+          ##       NixOS/nixpkgs#204606 makes it into a release.
+          inputs.bash-strict-mode.lib.drv pkgs
+          (pkgs.mkShell {
+            inputsFrom =
+              builtins.attrValues inputs.self.checks.${system}
+              ++ builtins.attrValues inputs.self.packages.${system};
+
+            nativeBuildInputs = [
+              # Nix language server,
+              # https://github.com/oxalica/nil#readme
+              pkgs.nil
+              # Bash language server,
+              # https://github.com/bash-lsp/bash-language-server#readme
+              pkgs.nodePackages.bash-language-server
+            ];
+          });
+
+        checks = {
+          eldev-doctor =
+            inputs.bash-strict-mode.lib.checkedDrv pkgs
+            (pkgs.stdenv.mkDerivation {
+              inherit ELDEV_LOCAL src;
+
+              name = "eldev-doctor";
+
+              nativeBuildInputs = [
+                pkgs.emacs
+                # Emacs-lisp build tool, https://doublep.github.io/eldev/
+                pkgs.emacsPackages.eldev
+              ];
+
+              buildPhase = ''
+                runHook preBuild
+                eldev doctor
+                runHook postBuild
+              '';
+
+              installPhase = ''
+                runHook preInstall
+                mkdir -p "$out"
+                runHook postInstall
+              '';
+            });
+
+          eldev-lint =
+            inputs.bash-strict-mode.lib.checkedDrv pkgs
+            (pkgs.stdenv.mkDerivation {
+              inherit ELDEV_LOCAL src;
+
+              name = "eldev-lint";
+
+              nativeBuildInputs = [
+                pkgs.emacs
+                pkgs.emacsPackages.eldev
+              ];
+
+              postPatch = ''
+                { echo
+                  echo "(mapcar"
+                  echo " 'eldev-use-local-dependency"
+                  echo " '(\"${emacsPath pkgs.emacsPackages.dash}\""
+                  echo "   \"${emacsPath pkgs.emacsPackages.elisp-lint}\""
+                  echo "   \"${emacsPath pkgs.emacsPackages.package-lint}\""
+                  echo "   \"${emacsPath pkgs.emacsPackages.relint}\""
+                  echo "   \"${emacsPath pkgs.emacsPackages.xr}\"))"
+                } >> Eldev
+              '';
+
+              buildPhase = ''
+                runHook preBuild
+                ## TODO: Currently needed to make a temp file in
+                ##      `eldev--create-internal-pseudoarchive-descriptor`.
+                export HOME="$PWD/fake-home"
+                mkdir -p "$HOME"
+                ## NB: Need `--external` here so that we don’t try to download any
+                ##     package archives (which would break the sandbox).
+                ## TODO: Re-enable relint, currently it errors, I think because it
+                ##       or Eldev is expecting a multi-file package.
+                eldev --external lint elisp # re
+                runHook postBuild
+              '';
+
+              installPhase = ''
+                runHook preInstall
+                mkdir -p "$out"
+                runHook preInstall
+              '';
+            });
+
+          nix-fmt = pkgs.stdenv.mkDerivation {
+            inherit src;
+
+            name = "nix fmt";
+
+            nativeBuildInputs = [self'.formatter];
+
+            buildPhase = ''
+              runHook preBuild
+              alejandra --check .
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p "$out"
+              runHook preInstall
+            '';
+          };
+        };
+
+        # Nix code formatter, https://github.com/kamadorueda/alejandra#readme
+        formatter = pkgs.alejandra;
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -71,11 +71,11 @@
 
         agenix-el =
           inputs.bash-strict-mode.lib.checkedDrv pkgs
-          (pkgs.emacsPackages.trivialBuild (let
+          (pkgs.emacsPackages.trivialBuild {
+            inherit ELDEV_LOCAL src;
+
             pname = "agenix";
             version = "0.2";
-          in {
-            inherit ELDEV_LOCAL pname src version;
 
             nativeBuildInputs = [
               pkgs.emacs
@@ -98,7 +98,7 @@
               eldev --packaged test
               runHook postInstallCheck
             '';
-          }));
+          });
       };
 
       devShells.default =

--- a/flake.nix
+++ b/flake.nix
@@ -197,6 +197,26 @@
               runHook preInstall
             '';
           });
+
+        nix-fmt = pkgs.stdenv.mkDerivation {
+          inherit src;
+
+          name = "nix fmt";
+
+          nativeBuildInputs = [inputs.self.formatter.${system}];
+
+          buildPhase = ''
+            runHook preBuild
+            alejandra --check .
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+            runHook preInstall
+          '';
+        };
       };
 
       # Nix code formatter, https://github.com/kamadorueda/alejandra#readme

--- a/flake.nix
+++ b/flake.nix
@@ -2,19 +2,19 @@
   description = "Decrypt and encrypt agenix secrets inside Emacs";
 
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
+
     bash-strict-mode = {
+      url = "github:sellout/bash-strict-mode";
       inputs.nixpkgs.follows = "nixpkgs";
-      url = github:sellout/bash-strict-mode;
     };
 
-    flake-utils.url = github:numtide/flake-utils;
+    flake-utils.url = "github:numtide/flake-utils";
 
     homeManager = {
+      url = "github:nix-community/home-manager/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
-      url = github:nix-community/home-manager/release-22.11;
     };
-
-    nixpkgs.url = github:NixOS/nixpkgs/release-22.11;
   };
 
   outputs = inputs:

--- a/nix/dependencies.nix
+++ b/nix/dependencies.nix
@@ -1,0 +1,12 @@
+final: prev: {
+  emacsPackagesFor = emacs:
+    (prev.emacsPackagesFor emacs).overrideScope' (efinal: eprev: {
+      # The `eldev` package doesn’t expose the executable.
+      eldev = eprev.eldev.overrideAttrs (old: {
+        postInstall = ''
+          mkdir -p "$out"
+          cp -R "$src/bin" "$out/"
+        '';
+      });
+    });
+}

--- a/nix/home-manager-example.nix
+++ b/nix/home-manager-example.nix
@@ -1,0 +1,11 @@
+{pkgs, ...}: {
+  programs.emacs = {
+    enable = true;
+    extraConfig = ''
+      (custom-set-variables
+       '(agenix-age-program "${pkgs.age}/bin/age"))
+      (require 'agenix)
+    '';
+    extraPackages = epkgs: [epkgs.agenix];
+  };
+}


### PR DESCRIPTION
This provides

- two overlays (one for emacsPackages, one for nixpkgs),
- a minimal example homeConfiguration for testing,
- a fully-featured package for agenix.el (byte compiles and runs tests (there are none yet)),
- a devShell including development tooling, and
- multiple checks (running linters).