### PR TITLE
Allow password protected private keys.

### DIFF
--- a/agenix.el
+++ b/agenix.el
@@ -123,8 +123,7 @@ Please close the buffer and try again"))))
 
 (defun agenix--decrypt-current-buffer-using-cleartext-identities (cleartext-identities)
   "Decrypt current buffer in place using CLEARTEXT-IDENTITIES.
-Called as part of AGENIX-DECRYPT-BUFFER which sets the buffer and some variables,
-and does some more validation."
+Called as part of AGENIX-DECRYPT-BUFFER."
   (let* (;; we make sure that all files actually exist
          (filtered-cleartext-identities
           (seq-filter (lambda (identity)
@@ -181,6 +180,7 @@ Error: %s" (buffer-file-name) nix-output)
           (setq agenix--encrypted-fp (buffer-file-name))
           (setq agenix--keys keys)
 
+          ;; Check if file already exists
           (if (not (file-exists-p (buffer-file-name)))
               (progn
                 (message "Not decrypting. File %s does not exist and will be created when you \
@@ -189,13 +189,14 @@ will save this buffer." (buffer-file-name))
             ;; if no key files in `agenix-key-files` are password protected, just proceed
             (if (seq-every-p (lambda (x) (not (agenix--identity-protected-p x)))
                              resolved-agenix-key-files)
-                (agenix--decrypt-current-buffer-using-cleartext-identities resolved-agenix-key-files)
+                (agenix--decrypt-current-buffer-using-cleartext-identities
+                 resolved-agenix-key-files)
               ;; else, pick one file and possibly decrypt it
               (let* ((temp-identity-path nil)
-                     (selected-identity-path (expand-file-name
-                                              (completing-read "Select private key to use \
-(or enter a custom path): "
-                                                               resolved-agenix-key-files nil nil))))
+                     (selected-identity-path
+                      (expand-file-name
+                       (completing-read "Select private key to use (or enter a custom path): "
+                                        resolved-agenix-key-files nil nil))))
                 (unwind-protect
                     (progn
                       (if (agenix--identity-protected-p selected-identity-path)

--- a/agenix.el
+++ b/agenix.el
@@ -109,6 +109,18 @@ See also https://security.stackexchange.com/a/245767/318401."
 (defun agenix--prompt-password (identity-file)
   "Prompt for the password of IDENTITY-FILE."
   (read-passwd (format "Password for %s: " identity-file)))
+
+(defun agenix--create-temp-identity (identity-path password)
+  "Create a temporary copy of IDENTITY-PATH and remove its password protection.
+PASSWORD is the current password of the identity file.
+See also https://stackoverflow.com/a/112409/5616591.''"
+  (let* ((temp-file (make-temp-file "agenix-temp-identity"))
+         (copy-cmd (format "cp %s %s" identity-path temp-file))
+         (rekey-cmd (format "ssh-keygen -p -P \"%s\" -N \"\" -f %s" password temp-file)))
+    (shell-command copy-cmd)
+    (shell-command rekey-cmd)
+    temp-file))
+
 (defun agenix--process-exit-code-and-output (program &rest args)
   "Run PROGRAM with ARGS and return the exit code and output in a list."
   (let ((identity-path (agenix--extract-identity-path args)))

--- a/agenix.el
+++ b/agenix.el
@@ -30,8 +30,6 @@
 
 ;;; Code:
 
-(require 'cl-lib)
-
 (defcustom agenix-age-program "age"
   "The age program."
   :group 'agenix
@@ -89,17 +87,6 @@ FUNC takes a temporary buffer that will be disposed after the call."
          (res (funcall func age-buf)))
     (kill-buffer age-buf)
     res))
-
-(defun agenix--extract-identity-path (args)
-  "Extract the path of the identity file from ARGS.
-Check if the file exists and is readable."
-  (let ((identity-index (or (cl-position "--identity" args :test 'string=)
-                            (cl-position "-i" args :test 'string=))))
-    (when identity-index
-      (let ((identity-path (nth (1+ identity-index) args)))
-        (if (and identity-path (file-readable-p identity-path))
-            identity-path
-          (error "Identity file %s does not exist or is not readable" identity-path))))))
 
 (defun agenix--identity-protected-p (identity-path)
   "Check if the identity file at IDENTITY-PATH is password protected.

--- a/agenix.el
+++ b/agenix.el
@@ -105,6 +105,10 @@ Returns t if the file is protected, nil if it's unprotected.
 See also https://security.stackexchange.com/a/245767/318401."
   (/= 0 (call-process "ssh-keygen" nil nil nil
                       "-y" "-P" "" "-f" identity-path)))
+
+(defun agenix--prompt-password (identity-file)
+  "Prompt for the password of IDENTITY-FILE."
+  (read-passwd (format "Password for %s: " identity-file)))
 (defun agenix--process-exit-code-and-output (program &rest args)
   "Run PROGRAM with ARGS and return the exit code and output in a list."
   (let ((identity-path (agenix--extract-identity-path args)))

--- a/agenix.el
+++ b/agenix.el
@@ -170,15 +170,15 @@ If ENCRYPTED-BUFFER is unset or nil, decrypt the current buffer."
 Probably file %s is not declared as a secret in 'secrets.nix' file.
 Error: %s" (buffer-file-name) nix-output)
         (let* ((keys (json-parse-string nix-output :array-type 'list))
-               (age-flags (list "--decrypt")))
+               (age-flags (list "--decrypt"))
+               (selected-key (expand-file-name
+                              (completing-read "Select private key to use (or enter a custom path): "
+                                               agenix-key-files nil nil)))
+               (temp-identity-path nil))
 
-          ;; Add all user's keys to the age command
-          (dolist (keyspec agenix-key-files)
-            (let ((key-path (cond ((stringp keyspec) keyspec)
-                                  (t (funcall keyspec)))))
-              (when (and key-path (file-exists-p (expand-file-name key-path)))
-                (setq age-flags
-                      (nconc age-flags (list "--identity" (expand-file-name key-path)))))))
+          ;; Add the selected key to the age command
+          (when (and selected-keys (file-exists-p (car selected-keys)))
+            (setq age-flags (nconc age-flags (list "--identity" (car selected-keys)))))
 
           ;; Add file-path to decrypt to the age command
           (setq age-flags (nconc age-flags (list (buffer-file-name))))

--- a/agenix.el
+++ b/agenix.el
@@ -125,9 +125,15 @@ Please close the buffer and try again"))))
   "Decrypt current buffer in place using CLEARTEXT-IDENTITIES.
 Called as part of AGENIX-DECRYPT-BUFFER which sets the buffer and some variables,
 and does some more validation."
-  (let* ((age-flags (append (list "--decrypt")
-                            (nconc (mapcan (lambda (identity) (list "--identity" identity))
-                                           cleartext-identities))
+  (let* ((filtered-cleartext-identities
+          (seq-filter (lambda (identity)
+                        (and identity
+                             (file-exists-p (expand-file-name identity))))
+                      cleartext-identities))
+         (age-flags (append (list "--decrypt")
+                            (mapcan (lambda (identity)
+                                      (list "--identity" (expand-file-name identity)))
+                                    filtered-cleartext-identities)
                             (list (buffer-file-name))))
          (age-res (apply #'agenix--process-exit-code-and-output agenix-age-program age-flags))
          (age-exit-code (car age-res))

--- a/agenix.el
+++ b/agenix.el
@@ -124,28 +124,10 @@ See also https://stackoverflow.com/a/112409/5616591.''"
     temp-file))
 
 (defun agenix--process-exit-code-and-output (program &rest args)
-  "Run PROGRAM with ARGS and return the exit code and output in a list.
-However, run additional logic for password-protected identity files.
-In particular: First find the identity file from the args and check whether it
-exists, is readable, and then whether it is password protected. If it is not
-password protected, proceed to make the program call. However, if it is password
-protected, prompt the user for the password. Then, copy the private key into a
-tmpfile and remove the password from the private key in this tmpfile. Finally,
-pass this tmpfile as the identity file, make the program call, and then remove
-the tmpfile again."
-  (let* ((identity-path (agenix--extract-identity-path args))
-         (temp-identity-path nil))
-    (when identity-path
-      (when (agenix--identity-protected-p identity-path)
-        (let ((password (agenix--prompt-password identity-path)))
-          (setq temp-identity-path (agenix--create-temp-identity identity-path password))
-          (setq args (cl-substitute temp-identity-path identity-path args :test #'string=)))))
-    (unwind-protect  ;; Make sure we always remove the temp-identity-path
-        (agenix--with-temp-buffer
-         (lambda (buf) (list (apply #'call-process program nil buf nil args)
-                             (agenix--buffer-string* buf))))
-      (when temp-identity-path
-        (delete-file temp-identity-path)))))
+  "Run PROGRAM with ARGS and return the exit code and output in a list."
+  (agenix--with-temp-buffer
+   (lambda (buf) (list (apply #'call-process program nil buf nil args)
+                       (agenix--buffer-string* buf)))))
 
 ;;;###autoload
 (defun agenix-decrypt-buffer (&optional encrypted-buffer)

--- a/agenix.el
+++ b/agenix.el
@@ -143,21 +143,21 @@ Probably file %s is not declared as a secret in 'secrets.nix' file.
 Error: %s" (buffer-file-name) nix-output)
         (let* ((keys (json-parse-string nix-output :array-type 'list))
                (age-flags (list "--decrypt"))
-               (selected-key (expand-file-name
-                              (completing-read "Select private key to use (or enter a custom path): "
-                                               agenix-key-files nil nil)))
+               (selected-identity-path (expand-file-name
+                                        (completing-read "Select private key to use (or enter a custom path): "
+                                                         agenix-key-files nil nil)))
                (temp-identity-path nil))
 
           ;; make sure we always delete temp-identity-path, as it may have the plaintext key
           (unwind-protect
               (progn
                 ;; Check if the selected key is password-protected
-                (when (and selected-key (file-exists-p selected-key))
-                  (if (agenix--identity-protected-p selected-key)
-                      (let ((password (agenix--prompt-password selected-key)))
-                        (setq temp-identity-path (agenix--create-temp-identity selected-key password))
+                (when (and selected-identity-path (file-exists-p selected-identity-path))
+                  (if (agenix--identity-protected-p selected-identity-path)
+                      (let ((password (agenix--prompt-password selected-identity-path)))
+                        (setq temp-identity-path (agenix--create-temp-identity selected-identity-path password))
                         (setq age-flags (nconc age-flags (list "--identity" temp-identity-path))))
-                    (setq age-flags (nconc age-flags (list "--identity" selected-key)))))
+                    (setq age-flags (nconc age-flags (list "--identity" selected-identity-path)))))
 
                 ;; Add file-path to decrypt to the age command
                 (setq age-flags (nconc age-flags (list (buffer-file-name))))

--- a/agenix.el
+++ b/agenix.el
@@ -110,8 +110,10 @@ See also https://stackoverflow.com/a/112409/5616591.''"
                                              "-p" "-P" password "-N" "" "-f" temp-file)))
           (if (= 0 rekey-exit-code)
               temp-file
-            (error "Failed to open private key %s. Wrong password? Please close the buffer and try again" identity-path)))
-      (error "Failed to create temporary copy of identity file. Please close the buffer and try again"))))
+            (error "Failed to open private key %s. Wrong password? \
+Please close the buffer and try again" identity-path)))
+      (error "Failed to create temporary copy of identity file. \
+Please close the buffer and try again"))))
 
 (defun agenix--process-exit-code-and-output (program &rest args)
   "Run PROGRAM with ARGS and return the exit code and output in a list."
@@ -180,17 +182,21 @@ will save this buffer." (buffer-file-name))
               ;; else, pick one file and possibly decrypt it
               (let* ((temp-identity-path nil)
                      (selected-identity-path (expand-file-name
-                                              (completing-read "Select private key to use (or enter a custom path): "
+                                              (completing-read "Select private key to use \
+(or enter a custom path): "
                                                                agenix-key-files nil nil))))
                 (unwind-protect
                     (progn
                       (if (agenix--identity-protected-p selected-identity-path)
                           (let ((password (agenix--prompt-password selected-identity-path)))
-                            (setq temp-identity-path (agenix--create-temp-identity selected-identity-path password)))
+                            (setq temp-identity-path
+                                  (agenix--create-temp-identity selected-identity-path password)))
                         (setq temp-identity-path selected-identity-path))
-                      (agenix--decrypt-current-buffer-using-cleartext-identities (list temp-identity-path)))
+                      (agenix--decrypt-current-buffer-using-cleartext-identities
+                       (list temp-identity-path)))
                   ;; Clean up temporary identity file, which may contain plaintext secret.
-                  (when (and temp-identity-path (not (equal temp-identity-path selected-identity-path)))
+                  (when (and temp-identity-path
+                             (not (equal temp-identity-path selected-identity-path)))
                     (delete-file temp-identity-path)))))))))))
 
 ;;;###autoload

--- a/agenix.el
+++ b/agenix.el
@@ -99,6 +99,12 @@ Check if the file exists and is readable."
             identity-path
           (error "Identity file %s does not exist or is not readable" identity-path))))))
 
+(defun agenix--identity-protected-p (identity-path)
+  "Check if the identity file at IDENTITY-PATH is password protected.
+Returns t if the file is protected, nil if it's unprotected.
+See also https://security.stackexchange.com/a/245767/318401."
+  (/= 0 (call-process "ssh-keygen" nil nil nil
+                      "-y" "-P" "" "-f" identity-path)))
 (defun agenix--process-exit-code-and-output (program &rest args)
   "Run PROGRAM with ARGS and return the exit code and output in a list."
   (let ((identity-path (agenix--extract-identity-path args)))


### PR DESCRIPTION
Currently, password protected private keys or identity files are not supported, because when `age` is run and prompts for the password, agenix.el currently can't forward the prompt to the user.
Note also that age doesn't support an ssh-agent.

I first tried an approach that catches the password prompt and forwards it to the user, but that was a big mess.
Instead I have now implemented the following logic.

In `agenix--process-exit-code-and-output`, first find the identity file from the args and check whether it exists, is readable, and then whether it is password protected.
If it is not password protected, proceed as before. However, if it is password protected, prompt the user for the password. (This prompt is therefore not coming from age but from this package.)

Then, copy the private key into a tmpfile and remove the password from the private key in this tmpfile.
Then pass this tmpfile as the identity file and remove it again.